### PR TITLE
Fixed namespace for Ssl

### DIFF
--- a/lib/Namecheap/Api/Ssl/Ssl.php
+++ b/lib/Namecheap/Api/Ssl/Ssl.php
@@ -1,5 +1,5 @@
 <?php
-namespace Namecheap\Ssl;
+namespace Namecheap\Api\Ssl;
 
 use Namecheap\Api\Namecheap;
 


### PR DESCRIPTION
This class was in the wrong namespace. Now it can be instantiated by

``` php
$namecheapSsl = new Namecheap\Api\Ssl\Ssl($client);
```
